### PR TITLE
Update IntakeCommand and related subsystems to reflect actual robot hardware

### DIFF
--- a/src/main/java/org/frc571/bradley/commands/IntakeCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/IntakeCommand.java
@@ -1,66 +1,27 @@
 
 package org.frc571.bradley.commands;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
-import org.frc571.bradley.subsystems.Index;
-import org.frc571.bradley.subsystems.Intake;
-import org.frc571.bradley.Constants.SpeedConstants;
-
-public class IntakeCommand extends CommandBase {
-
-    private final Index index;
-    private final Intake intake;
+public class IntakeCommand extends SequentialCommandGroup {
 
     public IntakeCommand() {
-
-        index = Index.getInstance();
-        addRequirements(index);
-        intake = Intake.getInstance();
-        addRequirements(index);
-
+        new LowerIntake();
+        new ParallelDeadlineGroup(
+                new RunIndexCommand(),
+                new RunIntakeCommand());
+        new ParallelDeadlineGroup(
+            new RaiseIntake(),
+            new ReverseIndexCommand()
+        );
     }
 
     // Called when the command is initially scheduled.
-    @Override
-    public void initialize() {
-        LowerIntake lower = new LowerIntake();
-        while (!lower.isFinished()) {
-            // wait while intake lowers
-        }
-    }
-
-    // Called every time the scheduler runs while the command is scheduled.
-    @Override
-    public void execute() {
-        index.turn();
-        intake.setSpeed(SpeedConstants.kIntakeMotorSpeed);
-    }
-
-    // Called once the command ends or is interrupted.
-    @Override
-    public void end(boolean interrupted) {
-        index.stop();
-        intake.setSpeed(-SpeedConstants.kIntakeMotorSpeed);
-        RaiseIntake raise = new RaiseIntake();
-        while (!raise.isFinished()) {
-            // wait while intake raises
-        }
-        intake.stop();
-    }
-
-    // Returns true when the command should end.
-    @Override
-    public boolean isFinished() {
-        if (index.getFrontInput() && index.getBackInput()) {
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public boolean runsWhenDisabled() {
         return false;
 
     }
+
 }

--- a/src/main/java/org/frc571/bradley/commands/IntakeCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/IntakeCommand.java
@@ -24,28 +24,35 @@ public class IntakeCommand extends CommandBase {
     // Called when the command is initially scheduled.
     @Override
     public void initialize() {
-        intake.setSpeed(SpeedConstants.kIntakeMotorSpeed);
+        LowerIntake lower = new LowerIntake();
+        while (!lower.isFinished()) {
+            // wait while intake lowers
+        }
     }
 
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        if (index.getFrontInput()) {
-            index.turn();
-        }
+        index.turn();
+        intake.setSpeed(SpeedConstants.kIntakeMotorSpeed);
     }
 
     // Called once the command ends or is interrupted.
     @Override
     public void end(boolean interrupted) {
         index.stop();
+        intake.setSpeed(-SpeedConstants.kIntakeMotorSpeed);
+        RaiseIntake raise = new RaiseIntake();
+        while (!raise.isFinished()) {
+            // wait while intake raises
+        }
         intake.stop();
     }
 
     // Returns true when the command should end.
     @Override
     public boolean isFinished() {
-        if (index.getMiddleInput() || index.getBackInput()) {
+        if (index.getFrontInput() && index.getBackInput()) {
             return true;
         }
         return false;

--- a/src/main/java/org/frc571/bradley/commands/ReverseIndexCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/ReverseIndexCommand.java
@@ -1,0 +1,38 @@
+package org.frc571.bradley.commands;
+
+import org.frc571.bradley.subsystems.Index;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+
+public class ReverseIndexCommand extends CommandBase {
+    private Index index;
+
+    public ReverseIndexCommand() {
+        index = Index.getInstance();
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public void execute() {
+        index.reverse();
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        index.stop();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public boolean runsWhenDisabled() {
+        return false;
+    }
+
+}

--- a/src/main/java/org/frc571/bradley/commands/RunIndexCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/RunIndexCommand.java
@@ -1,0 +1,38 @@
+package org.frc571.bradley.commands;
+
+import org.frc571.bradley.subsystems.Index;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+
+public class RunIndexCommand extends CommandBase {
+    private Index index;
+
+    public RunIndexCommand() {
+        index = Index.getInstance();
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public void execute() {
+        index.turn();
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        index.stop();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return (index.getFrontInput() && index.getBackInput());
+    }
+
+    @Override
+    public boolean runsWhenDisabled() {
+        return false;
+    }
+
+}

--- a/src/main/java/org/frc571/bradley/commands/RunIntakeCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/RunIntakeCommand.java
@@ -1,0 +1,39 @@
+package org.frc571.bradley.commands;
+
+import org.frc571.bradley.Constants.SpeedConstants;
+import org.frc571.bradley.subsystems.Intake;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+
+public class RunIntakeCommand extends CommandBase {
+
+    private Intake intake;
+
+    public RunIntakeCommand() {
+        intake = Intake.getInstance();
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public void execute() {
+        intake.setSpeed(SpeedConstants.kIntakeMotorSpeed);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        intake.stop();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public boolean runsWhenDisabled() {
+        return false;
+    }
+}

--- a/src/main/java/org/frc571/bradley/commands/ShootCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/ShootCommand.java
@@ -15,7 +15,6 @@ public class ShootCommand extends CommandBase {
         
     }
 
-    // Called when the command is initially scheduled.
     @Override
     public void initialize() {
     }
@@ -26,7 +25,6 @@ public class ShootCommand extends CommandBase {
         m_shoot.shoot();
     }
 
-    // Called once the command ends or is interrupted.
     @Override
     public void end(boolean interrupted) {
     }

--- a/src/main/java/org/frc571/bradley/commands/StopIntakeCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/StopIntakeCommand.java
@@ -15,17 +15,14 @@ public class StopIntakeCommand extends CommandBase {
 
     }
 
-    // Called when the command is initially scheduled.
     @Override
     public void initialize() {
     }
 
-    // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
     }
 
-    // Called once the command ends or is interrupted.
     @Override
     public void end(boolean interrupted) {
     }

--- a/src/main/java/org/frc571/bradley/subsystems/Index.java
+++ b/src/main/java/org/frc571/bradley/subsystems/Index.java
@@ -12,7 +12,6 @@ public class Index extends ParagonSubsystemBase {
     private String name = "Index";
     private PWMVictorSPX IndexMotor;
     private DigitalInput frontInput;
-    private DigitalInput middleInput;
     private DigitalInput backInput;
 
     private Index() {
@@ -21,7 +20,6 @@ public class Index extends ParagonSubsystemBase {
         IndexMotor.setInverted(false);
 
         frontInput = new DigitalInput(Constants.DigitalConstants.kFrontInput);
-        middleInput = new DigitalInput(Constants.DigitalConstants.kMiddleInput);
         backInput = new DigitalInput(Constants.DigitalConstants.kBackInput);
     }
 
@@ -52,7 +50,6 @@ public class Index extends ParagonSubsystemBase {
 
     @Override
     public String getName() {
-        // TODO Auto-generated method stub
         return name;
     }
 
@@ -67,10 +64,6 @@ public class Index extends ParagonSubsystemBase {
 
     public boolean getFrontInput() {
         return frontInput.get();
-    }
-
-    public boolean getMiddleInput() {
-        return middleInput.get();
     }
 
     public boolean getBackInput() {

--- a/src/main/java/org/frc571/bradley/subsystems/Index.java
+++ b/src/main/java/org/frc571/bradley/subsystems/Index.java
@@ -72,4 +72,8 @@ public class Index extends ParagonSubsystemBase {
     public void turn() {
         IndexMotor.set(0.5);
     }
+
+    public void reverse() {
+        IndexMotor.set(-0.5);
+    }
 }

--- a/src/main/java/org/frc571/bradley/subsystems/Index.java
+++ b/src/main/java/org/frc571/bradley/subsystems/Index.java
@@ -5,6 +5,7 @@ import org.frc571.bradley.Constants;
 
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.motorcontrol.PWMVictorSPX;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class Index extends ParagonSubsystemBase {
     private static Index index;
@@ -32,19 +33,16 @@ public class Index extends ParagonSubsystemBase {
 
     @Override
     public void periodic() {
-        // This method will be called once per scheduler run
-
     }
 
     @Override
     public void simulationPeriodic() {
-        // This method will be called once per scheduler run when in simulation
-
     }
 
     @Override
     public void outputTelemetry() {
-        // TODO Add telemetry to smart dashboard
+        SmartDashboard.putBoolean(getName() + "/Front Input", frontInput.get());
+        SmartDashboard.putBoolean(getName() + "/Back Input", backInput.get());
 
     }
 
@@ -69,6 +67,7 @@ public class Index extends ParagonSubsystemBase {
     public boolean getBackInput() {
         return backInput.get();
     }
+
     public void turn() {
         IndexMotor.set(0.5);
     }


### PR DESCRIPTION
Fixes #35. Removed middleInput from Index subsystem. Changed logic in IntakeCommand. The intakeArm now lowers when the command is initialized and raises when finished. The indexer now runs for the duration of the command, stopping when it ends. 