### PR TITLE
Fix DriveCommand to continuously stream values

### DIFF
--- a/src/main/java/org/frc571/bradley/Constants.java
+++ b/src/main/java/org/frc571/bradley/Constants.java
@@ -19,6 +19,8 @@ public class Constants {
         public static final int kLeftMotorRearPort = 2;
         public static final int kRightMotorFrontPort = 3;
         public static final int kRightMotorRearPort = 4;
+        public static final double MAX_FORWARD_SPEED = 0.6;
+        public static final double MAX_TURNING_SPEED = 0.3;
     }
 
     public static final class MotorConstants {

--- a/src/main/java/org/frc571/bradley/Controller.java
+++ b/src/main/java/org/frc571/bradley/Controller.java
@@ -1,9 +1,10 @@
 package org.frc571.bradley;
 
 public class Controller {
-    public static double ApplyJoystickDeadzone(double value, double deadzone) {
+    public static double ApplyJoystickDeadzone(double rawValue, double deadzone) {
         double result;
         double validRange = Constants.ControlConstants.MAX_AXIS - deadzone;
+        double value = Math.abs(rawValue);
 
         if (value > deadzone) {
             result = (value - deadzone) / validRange;
@@ -12,6 +13,6 @@ public class Controller {
             result = 0;
         }
 
-        return result;
+        return rawValue < 0 ? -result : result;
     }
 }

--- a/src/main/java/org/frc571/bradley/RobotContainer.java
+++ b/src/main/java/org/frc571/bradley/RobotContainer.java
@@ -67,10 +67,10 @@ public class RobotContainer {
     // Configure default commands0
     m_drive.setDefaultCommand(
       new DriveCommand(
-        Controller.ApplyJoystickDeadzone(
+        () -> Controller.ApplyJoystickDeadzone(
           driveController.getLeftY(),
           Constants.ControlConstants.kDeadzone),
-        Controller.ApplyJoystickDeadzone(
+        () -> Controller.ApplyJoystickDeadzone(
           driveController.getRightX(),
           Constants.ControlConstants.kDeadzone)
       )

--- a/src/main/java/org/frc571/bradley/commands/DriveCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/DriveCommand.java
@@ -2,6 +2,7 @@ package org.frc571.bradley.commands;
 
 import java.util.function.DoubleSupplier;
 
+import org.frc571.bradley.Constants.DriveConstants;
 import org.frc571.bradley.subsystems.Drive;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -30,7 +31,8 @@ public class DriveCommand extends CommandBase {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        m_drive.drive(m_forward.getAsDouble() * Math.abs(m_forward.getAsDouble())*0.60, -m_turn.getAsDouble() * 0.30);
+        m_drive.drive(m_forward.getAsDouble() * Math.abs(m_forward.getAsDouble()) * DriveConstants.MAX_FORWARD_SPEED,
+            -m_turn.getAsDouble() * DriveConstants.MAX_TURNING_SPEED);
     }
 
     // Called once the command ends or is interrupted.

--- a/src/main/java/org/frc571/bradley/commands/DriveCommand.java
+++ b/src/main/java/org/frc571/bradley/commands/DriveCommand.java
@@ -1,5 +1,7 @@
 package org.frc571.bradley.commands;
 
+import java.util.function.DoubleSupplier;
+
 import org.frc571.bradley.subsystems.Drive;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -7,10 +9,10 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 public class DriveCommand extends CommandBase {
 
     private final Drive m_drive;
-    private final Double m_forward;
-    private final Double m_turn;
+    private final DoubleSupplier m_forward;
+    private final DoubleSupplier m_turn;
 
-    public DriveCommand(Double forward, Double turn) {
+    public DriveCommand(DoubleSupplier forward, DoubleSupplier turn) {
 
         m_forward = forward;
         m_turn = turn;
@@ -28,7 +30,7 @@ public class DriveCommand extends CommandBase {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-        m_drive.drive(m_forward * Math.abs(m_forward)*0.60, -m_turn * 0.30);
+        m_drive.drive(m_forward.getAsDouble() * Math.abs(m_forward.getAsDouble())*0.60, -m_turn.getAsDouble() * 0.30);
     }
 
     // Called once the command ends or is interrupted.


### PR DESCRIPTION
By changing DriveCommand to accept Double instead of DoubleSupplier,
only the initial value was read. This change restores reading a
stream of double values instead.

Closes #66.